### PR TITLE
Daily games and option to merge pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
 # chess_download_games
-This script will download all your chess.com live games
+This script will download all your chess.com games (both live and daily).
 
 You'll need python3 and Firefox installed.
 
 1. Install selenium
-
-python3 -m pip install selenium
+   ```bash
+   python3 -m pip install selenium
+   ```
 
 2. Download, unpack, and move geckodriver (for linux):
+   ```bash
+   wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
+   tar -xvzf geckodriver*
+   chmod +x geckodriver
+   sudo mv geckodriver /usr/local/bin/
+   ```
+   (Windows users, have a look [here](https://www.geeksforgeeks.org/how-to-install-selenium-in-python/).)
 
-wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz
+3. Run the script:
+   ```bash
+   python3 download_games.py
+   ```
 
-tar -xvzf geckodriver*
+By default, the games will be saved in the current working directory. 
+To specify a download directory, pass an argument to the script, e.g. 
+`python3 download_games.py ./games`. 
+By default, both live and daily games will be saved into a single `games.pgn` file;
+if you want to keep each separate, pass the `--separate-types` flag.
 
-chmod +x geckodriver
-
-sudo mv geckodriver /usr/local/bin/
-
-
-2.1. (Windows users, have a look here):
-
-https://www.geeksforgeeks.org/how-to-install-selenium-in-python/
-
-3. running the script:
-
-python3 download_games.py
-
-#your games will be saved in firefox's default download directory, unless you uncomment the lines 11 and 16 (linux users only), in which case a folder with the name 'games' will save the files.
+For more options and details on the command line interface, run
+```shell
+python3 download_games.py --help
+```

--- a/download_games.py
+++ b/download_games.py
@@ -1,5 +1,7 @@
 # downloading all my chess game
 import argparse
+import glob
+import os
 import pathlib
 from time import sleep
 
@@ -7,20 +9,86 @@ from selenium import webdriver
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from stdiomask import getpass
 
+PAGE_FILENAME_GLOB = "chess_com_games*"
+
+
+def set_string_preference(driver, name, value):
+    driver.execute_script("window.open()")
+    windows = driver.window_handles
+    driver.switch_to.window(windows[-1])
+
+    driver.get("about:config")
+    driver.execute_script(
+        """
+    var prefs = Components.classes["@mozilla.org/preferences-service;1"]
+        .getService(Components.interfaces.nsIPrefBranch);
+    prefs.setCharPref(arguments[0], arguments[1]);
+    """,
+        name,
+        value,
+    )
+
+    driver.close()
+    driver.switch_to.window(windows[-2])
+
+
+def merge_pages(*files, out):
+    with open(out, "w") as out:
+        for path in files:
+            with open(path) as page:
+                out.write(page.read())
+                out.write("\n")
+            os.remove(path)
+
+
 # ---------- arguments ----------
 argument_parser = argparse.ArgumentParser()
-argument_parser.add_argument("download_dir", nargs="?", default=None, type=pathlib.Path)
+argument_parser.add_argument(
+    "download_dir",
+    nargs="?",
+    default=".",
+    type=pathlib.Path,
+    help="The download directory; defaults to the current working directory.",
+)
+argument_parser.add_argument(
+    "--concatenate",
+    action="store_true",
+    default=True,
+    help="Concatenate all files containing a single page of games into one big file. "
+    "Each of the individual pages is then discarded. If --separate-types is set, two "
+    "files are created: `live.pgn` and `daily.pgn`. Otherwise, a single `games.pgn` "
+    "file is created. This is set by default.",
+)
+argument_parser.add_argument(
+    "--dont-concatenate",
+    action="store_false",
+    dest="concatenate",
+    help="The opposite of --concatenate. Each page is downloaded as a single file.",
+)
+argument_parser.add_argument(
+    "--separate-types",
+    action="store_true",
+    help="Separate game files into live games and daily games. "
+    "If --concatenate is set (default), a `live.pgn` file and a `daily.pgn` file are "
+    "created in the download directory. If --dont-concatenate is set, pages for live "
+    "and daily games are downloaded in the `live/` and `daily/` subdirectories "
+    "(within the download directory) respectively.",
+)
 argument_parser.add_argument(
     "--user",
     required=False,
     default="",
     type=lambda x: x or input("User: "),
+    help="The chess.com username for the user whose games are to be downloaded. If not "
+    "provided, it will be asked interactively.",
 )
 argument_parser.add_argument(
     "--password",
     required=False,
     default="",
     type=lambda x: x or getpass("Password: "),
+    help="The chess.com password for the user whose games are to be downloaded. If not "
+    "provided, it will be asked interactively.",
 )
 args = argument_parser.parse_args()
 
@@ -33,9 +101,8 @@ profile.set_preference(
     "application/vnd.chess-pgn, application/x-chess-pgn",
 )
 profile.set_preference("browser.download.folderList", 2)
-if args.download_dir is not None:
-    args.download_dir.mkdir(parents=True, exist_ok=True)
-    profile.set_preference("browser.download.dir", str(args.download_dir.absolute()))
+args.download_dir.mkdir(parents=True, exist_ok=True)
+profile.set_preference("browser.download.dir", str(args.download_dir.absolute()))
 
 # ---------- start the browser ----------
 with webdriver.Firefox(firefox_profile=profile) as browser:
@@ -54,18 +121,47 @@ with webdriver.Firefox(firefox_profile=profile) as browser:
     login_btt = browser.find_element_by_xpath("//button[@type='submit']")
     login_btt.click()
 
-    # ---------- download the games ----------
-    browser.get("https://www.chess.com/games/archive?gameOwner=my_game&gameType=live")
+    # ---------- download each page ----------
+    # note previously existing files to avoid using them or deleting them
+    existing_files = set(glob.glob(str(args.download_dir / PAGE_FILENAME_GLOB)))
 
-    while True:
-        check_all = browser.find_element_by_xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "archive-games-check-all", " " ))]')
-        check_all.click()
-        download = browser.find_element_by_xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "v-tooltip", " " ))]')
-        download.click()
-        sleep(0.5)
-        next_page = browser.find_element_by_xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "pagination-next", " " ))]')
+    for game_type in "live", "daily":
+        browser.get(f"https://www.chess.com/games/archive?gameOwner=my_game&gameType={game_type}")
 
-        try:
-            next_page.click()
-        except:
-            break
+        if args.separate_types and not args.concatenate:
+            subdir: pathlib.Path = args.download_dir / game_type
+            subdir.mkdir(parents=True, exist_ok=True)
+            set_string_preference(
+                browser, "browser.download.dir", str(subdir.absolute())
+            )
+            existing_files = set(glob.glob(str(subdir / PAGE_FILENAME_GLOB)))
+
+        while True:
+            check_all = browser.find_element_by_xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "archive-games-check-all", " " ))]')
+            check_all.click()
+            download = browser.find_element_by_xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "v-tooltip", " " ))]')
+            download.click()
+            sleep(0.5)
+
+            try:
+                next_page = browser.find_element_by_xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "pagination-next", " " ))]')
+                next_page.click()
+            except:
+                break
+
+        # ---------- concatenate pages into one file ----------
+        if args.separate_types and args.concatenate:
+            paths = sorted(
+                set(glob.glob(str(args.download_dir / PAGE_FILENAME_GLOB)))
+                - existing_files,
+                key=os.path.getmtime,
+            )
+            merge_pages(*paths, out=args.download_dir / f"{game_type}.pgn")
+
+    if not args.separate_types and args.concatenate:
+        paths = sorted(
+            set(glob.glob(str(args.download_dir / PAGE_FILENAME_GLOB)))
+            - existing_files,
+            key=os.path.getmtime,
+        )
+        merge_pages(*paths, out=args.download_dir / f"games.pgn")


### PR DESCRIPTION
Quick addition to #1.

This adds functionality to download daily games too along with live games; they can optionally be kept separate from each other with `--separate-types`. It also adds a `--concatenate` option (enabled by default) to merge all pages (files named `chess_com_games*`) into a  single file. Run `download_games.py --help` or read the source code for more details.

Due to having to work with subdirectories in the download directory if both `--dont-concatenate` and `--separate-types` are passed, the default download destination is no longer Firefox's default downloads folder. The new default behaviour if no arguments are passed is to download *all* games into a single `games.pgn` file in the current working directory. 

If you have any suggestions for improvement I'm happy to implement them. Feel free to edit this directly as you like, changing the defaults etc!